### PR TITLE
Move Info.plist. Add CFBundleVersion.

### DIFF
--- a/RangeSeekSlider.xcodeproj/project.pbxproj
+++ b/RangeSeekSlider.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		952CACB62040C70D00DA930D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE00D96D1E7AA99A0032CA93 /* CustomRangeSeekSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomRangeSeekSlider.swift; path = Demo/RangeSeekSliderDemo/CustomRangeSeekSlider.swift; sourceTree = SOURCE_ROOT; };
 		CE3D49B51E712B840071E992 /* RangeSeekSliderDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RangeSeekSliderDelegate.swift; sourceTree = "<group>"; };
 		CE3D49B81E71409A0071E992 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -188,6 +189,7 @@
 		OBJ_8 /* RangeSeekSlider */ = {
 			isa = PBXGroup;
 			children = (
+				952CACB62040C70D00DA930D /* Info.plist */,
 				OBJ_9 /* RangeSeekSlider.swift */,
 				CE3D49B51E712B840071E992 /* RangeSeekSliderDelegate.swift */,
 				CEBD453B1E9A42E4001AF6DF /* TapticEngine.swift */,
@@ -497,7 +499,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = RangeSeekSlider.xcodeproj/RangeSeekSlider_Info.plist;
+				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -520,7 +522,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = RangeSeekSlider.xcodeproj/RangeSeekSlider_Info.plist;
+				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>


### PR DESCRIPTION
- Move `Info.plist` file from inside project bundle directory to `Sources`.
- Set `CFBundleVersion` in `Info.plist` to fix issue [#34 Missing CFBundleVersion](https://github.com/WorldDownTown/RangeSeekSlider/issues/34).