### PR TITLE
Labels below slider. Converted to Swift 4.1

### DIFF
--- a/Demo/RangeSeekSliderDemo/Base.lproj/Main.storyboard
+++ b/Demo/RangeSeekSliderDemo/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="mFL-3X-bpM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="mFL-3X-bpM">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -139,6 +140,8 @@
                                                 <real key="value" value="500"/>
                                             </userDefinedRuntimeAttribute>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="enableStep" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="positionMinLabelAtBottom" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="positionMaxLabelAtBottom" value="YES"/>
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hidden Labels:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oXk-Mj-BG8">
@@ -168,9 +171,13 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="65" id="wa9-1w-B3f"/>
                                         </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="positionMinLabelAtBottom" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="positionMaxLabelAtBottom" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By WorldDownTown" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l8Q-0R-HSN">
-                                        <rect key="frame" x="230" y="716" width="128.5" height="17"/>
+                                        <rect key="frame" x="230.5" y="716" width="128" height="17"/>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -241,7 +248,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="mFL-3X-bpM" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="IJA-We-zv4">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/RangeSeekSlider.xcodeproj/project.pbxproj
+++ b/RangeSeekSlider.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 						ProvisioningStyle = Automatic;
 					};
 					OBJ_16 = {
+						DevelopmentTeam = Y82BZWEDP2;
 						ProvisioningStyle = Automatic;
 					};
 					OBJ_23 = {
@@ -490,7 +491,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y82BZWEDP2;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -513,7 +514,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y82BZWEDP2;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -587,7 +588,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -608,7 +609,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;

--- a/RangeSeekSlider.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RangeSeekSlider.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -489,11 +489,11 @@ import UIKit
         }
 
         if let nsstring = minLabel.string as? NSString {
-            minLabelTextSize = nsstring.size(attributes: [NSFontAttributeName: minLabelFont])
+            minLabelTextSize = nsstring.size(withAttributes: [NSAttributedStringKey.font: minLabelFont])
         }
 
         if let nsstring = maxLabel.string as? NSString {
-            maxLabelTextSize = nsstring.size(attributes: [NSFontAttributeName: maxLabelFont])
+            maxLabelTextSize = nsstring.size(withAttributes: [NSAttributedStringKey.font: maxLabelFont])
         }
     }
 

--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -55,6 +55,7 @@ import UIKit
             if selectedMinValue < minValue {
                 selectedMinValue = minValue
             }
+            self.setNeedsLayout()
         }
     }
 
@@ -65,6 +66,7 @@ import UIKit
             if selectedMaxValue > maxValue {
                 selectedMaxValue = maxValue
             }
+            self.setNeedsLayout()
         }
     }
 

--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -84,6 +84,21 @@ import UIKit
         }
     }
 
+    /// Changes the minimum value text label position. true = label will be positioned below the slider. false = label will be positioned above the slider.
+    @IBInspectable open var positionMinLabelAtBottom: Bool = false {
+        didSet {
+            updateLabelPositions()
+        }
+    }
+
+    /// Changes the maximum value text label position. true = label will be positioned below the slider. false = label will be positioned above the slider.
+    @IBInspectable open var positionMaxLabelAtBottom: Bool = false {
+        didSet {
+            updateLabelPositions()
+        }
+    }
+
+
     /// Each handle in the slider has a label above it showing the current selected value. By default, this is displayed as a decimal format.
     /// You can update this default here by updating properties of NumberFormatter. For example, you could supply a currency style, or a prefix or suffix.
     open var numberFormatter: NumberFormatter = {
@@ -561,11 +576,19 @@ import UIKit
 
         let minSpacingBetweenLabels: CGFloat = 8.0
 
+        var minLabelY: CGFloat = leftHandle.frame.minY - (minLabelTextSize.height / 2.0) - labelPadding
+        if positionMinLabelAtBottom {
+            minLabelY = leftHandle.frame.maxY + (minLabelTextSize.height / 2.0) + labelPadding
+        }
         let newMinLabelCenter: CGPoint = CGPoint(x: leftHandle.frame.midX,
-                                                 y: leftHandle.frame.minY - (minLabelTextSize.height / 2.0) - labelPadding)
+                                                 y: minLabelY)
 
+        var maxLabelY: CGFloat = rightHandle.frame.minY - (maxLabelTextSize.height / 2.0) - labelPadding
+        if positionMaxLabelAtBottom {
+            maxLabelY = rightHandle.frame.maxY + (maxLabelTextSize.height / 2.0) + labelPadding
+        }
         let newMaxLabelCenter: CGPoint = CGPoint(x: rightHandle.frame.midX,
-                                                 y: rightHandle.frame.minY - (maxLabelTextSize.height / 2.0) - labelPadding)
+                                                 y: maxLabelY)
 
         let newLeftMostXInMaxLabel: CGFloat = newMaxLabelCenter.x - maxLabelTextSize.width / 2.0
         let newRightMostXInMinLabel: CGFloat = newMinLabelCenter.x + minLabelTextSize.width / 2.0
@@ -606,10 +629,20 @@ import UIKit
     }
 
     private func updateFixedLabelPositions() {
+        var minLabelY: CGFloat = sliderLine.frame.minY - (minLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding
+        if positionMinLabelAtBottom {
+            minLabelY = sliderLine.frame.maxY + (minLabelTextSize.height / 2.0) + (handleDiameter / 2.0) + labelPadding
+        }
+        var maxLabelY: CGFloat = sliderLine.frame.minY - (maxLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding
+        if positionMaxLabelAtBottom {
+            maxLabelY = sliderLine.frame.maxY + (maxLabelTextSize.height / 2.0) + (handleDiameter / 2.0) + labelPadding
+        }
+
         minLabel.position = CGPoint(x: xPositionAlongLine(for: minValue),
-                                    y: sliderLine.frame.minY - (minLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding)
+                                    y: minLabelY)
         maxLabel.position = CGPoint(x: xPositionAlongLine(for: maxValue),
-                                    y: sliderLine.frame.minY - (maxLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding)
+                                    y: maxLabelY)
+
         if minLabel.frame.minX < 0.0 {
             minLabel.frame.origin.x = 0.0
         }


### PR DESCRIPTION
Added IBInspectable properties that allow choosing whether the labels should be displayed above or below the slider.

Swift 4 compatibility.