### PR TITLE
compatibility for Swift 5

### DIFF
--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -374,7 +374,7 @@ import UIKit
 
     open override func index(ofAccessibilityElement element: Any) -> Int {
         guard let element = element as? UIAccessibilityElement else { return 0 }
-        return accessibleElements.index(of: element) ?? 0
+        return accessibleElements.firstIndex(of: element) ?? 0
     }
 
 


### PR DESCRIPTION
"index(of:)" has been deprecated and is now renamed to "firstIndex(of:)"