### PR TITLE
Add flexibility to labels and handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ Each handle in the slider has a label above it showing the current selected valu
 When set to `true` the labels above the slider controls will be hidden. Default is `false`.
 
 #### `labelsFixed`
-Fixes the labels above the slider controls. If `true`, labels will be fixed to both ends. Otherwise labels will move with the handles. Default is `false`.
+Fixes the labels on the edges of the slider controls. If `true`, labels will be fixed to both ends. Otherwise labels will move with the handles. Default is `false`.
+
+#### `labelsAbove`
+Render the labels above the slider control. If `true`, labels wil be above the slider. Otherwise labels will be below. Default is `false`.
 
 #### `minDistance`
 The minimum distance the two selected slider values must be apart. Default is `0.0`.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ If `enableStep` is `true`, this controls the value of each step. E.g. if this va
 #### `handleImage`
 If set the image passed will be used for the handles.
 
+#### `handleOffset`
+If set it will add an offset to the the handles. Default is `x:0, y:0`.
+
 #### `handleDiameter`
 If set it will update the size of the handles. Default is `16.0`.
 

--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -101,8 +101,10 @@ import UIKit
         }
     }
 
-    /// fixes the labels above the slider controls. true: labels will be fixed to both ends. false: labels will move with the handles. Default is false.
+    /// fixes the labels on the edges of the slider controls. true: labels will be fixed to both ends. false: labels will move with the handles. Default is false.
     @IBInspectable open var labelsFixed: Bool = false
+    /// render the labels above the slider control. true: labels wil be above the slider. false: labels will be below
+    @IBInspectable open var labelsAbove: Bool = false
 
     /// The minimum distance the two selected slider values must be apart. Default is 0.
     @IBInspectable open var minDistance: CGFloat = 0.0 {
@@ -562,10 +564,10 @@ import UIKit
         let minSpacingBetweenLabels: CGFloat = 8.0
 
         let newMinLabelCenter: CGPoint = CGPoint(x: leftHandle.frame.midX,
-                                                 y: leftHandle.frame.maxY + (minLabelTextSize.height/2) + labelPadding)
+                                                 y: labelsAbove ? leftHandle.frame.minY - (minLabelTextSize.height/2) - labelPadding : leftHandle.frame.maxY + (minLabelTextSize.height/2) + labelPadding)
 
         let newMaxLabelCenter: CGPoint = CGPoint(x: rightHandle.frame.midX,
-                                                 y: rightHandle.frame.maxY + (maxLabelTextSize.height/2) + labelPadding)
+                                                 y: labelsAbove ? rightHandle.frame.minY - (maxLabelTextSize.height/2) - labelPadding : rightHandle.frame.maxY + (maxLabelTextSize.height/2) + labelPadding)
         
         let newLeftMostXInMaxLabel: CGFloat = newMaxLabelCenter.x - maxLabelTextSize.width / 2.0
         let newRightMostXInMinLabel: CGFloat = newMinLabelCenter.x + minLabelTextSize.width / 2.0
@@ -607,9 +609,9 @@ import UIKit
 
     private func updateFixedLabelPositions() {
         minLabel.position = CGPoint(x: xPositionAlongLine(for: minValue),
-                                    y: sliderLine.frame.minY - (minLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding)
+                                    y: labelsAbove ? sliderLine.frame.minY - (minLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding : sliderLine.frame.maxY + (minLabelTextSize.height / 2.0) + (handleDiameter / 2.0) + labelPadding)
         maxLabel.position = CGPoint(x: xPositionAlongLine(for: maxValue),
-                                    y: sliderLine.frame.minY - (maxLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding)
+                                    y: labelsAbove ? sliderLine.frame.minY - (maxLabelTextSize.height / 2.0) - (handleDiameter / 2.0) - labelPadding : sliderLine.frame.maxY + (maxLabelTextSize.height / 2.0) + (handleDiameter / 2.0) + labelPadding)
         if minLabel.frame.minX < 0.0 {
             minLabel.frame.origin.x = 0.0
         }

--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -176,6 +176,9 @@ import UIKit
         }
     }
 
+    /// Handle offset (default (x:0, y:0))
+    @IBInspectable open var handleOffset: CGPoint = CGPoint(x: 0, y: 0)
+    
     /// Handle diameter (default 16.0)
     @IBInspectable open var handleDiameter: CGFloat = 16.0 {
         didSet {
@@ -537,11 +540,11 @@ import UIKit
     }
 
     private func updateHandlePositions() {
-        leftHandle.position = CGPoint(x: xPositionAlongLine(for: selectedMinValue),
-                                      y: sliderLine.frame.midY)
+        leftHandle.position = CGPoint(x: xPositionAlongLine(for: selectedMinValue) + handleOffset.x,
+                                      y: sliderLine.frame.midY + handleOffset.y)
 
-        rightHandle.position = CGPoint(x: xPositionAlongLine(for: selectedMaxValue),
-                                       y: sliderLine.frame.midY)
+        rightHandle.position = CGPoint(x: xPositionAlongLine(for: selectedMaxValue) + handleOffset.x,
+                                       y: sliderLine.frame.midY + handleOffset.y)
 
         // positioning for the dist slider line
         sliderLineBetweenHandles.frame = CGRect(x: leftHandle.position.x,


### PR DESCRIPTION
With the changes in this PR it will be possible to 
- choose between labels above and below the slider while still being able to use the "fixed" attribute
- add an offset to the handle to allow more flexible handle designs

